### PR TITLE
fixed a mongodb duplicate keys error

### DIFF
--- a/public/new.html
+++ b/public/new.html
@@ -111,8 +111,8 @@
             <p class="love">Love</p>
             <p class="light">Light</p>
             <div class="sign-buttons">
-                <div class="sign-up">
-                    <div onclick="location.href='nickname.html'">Sign up </div>
+                <div class="sign-up" onclick="location.href='nickname.html'">
+                    <div >Sign up </div>
                 </div>
                 <div class="sign-in">
                     <div id="google-signin-container">

--- a/public/partnerInvite.html
+++ b/public/partnerInvite.html
@@ -59,7 +59,7 @@
         <button type="submit">Submit</button>
     </form>
 
-    <h1>OR accept your invite with an invite code</h1>
+    <h1>Accept Invite</h1>
     <form id="accept-invite-form">
         <input type="text" id="inviteCode" placeholder="Invite Code">
         <button type="submit">Submit</button>
@@ -119,6 +119,7 @@
         .then(data => {
             console.log(data, "data")
             if (data.msg === 1) { // Check if the response indicates success
+                console.log("Email is unique")
                 return fetch('/resend/sendInvite', {
                     method: "POST",
                     headers: {
@@ -128,14 +129,16 @@
                         email: invterEmail,
                         nickname: `${clientNickname}`
                     })
-                });
+                })
+                .then(response => {
+                    console.log(response.status, "response status")
+                })
+                .then(data => console.log(data))
+                .catch(error => console.error('Error:', error));
             } else {
                 throw new Error('Email is not unique');
             }
         })
-        .then(response => response.json())
-        .then(data => console.log(data))
-        .catch(error => console.error('Error:', error));
         
 
 

--- a/resend/invitation-template.js
+++ b/resend/invitation-template.js
@@ -64,7 +64,7 @@ const generateInviteEmail = (recipient, inviteCode) => {
                 Hi ${recipient}'s partner,
             </p>
             <p>
-                We're excited to have you on board! Below is your exclusive invite code to access our platform:
+                We're excited to have you on board! Below is the invite code you can use to connect your account with ${recipient}'s account and share your feelings with each other. 
             </p>
             <p>
                 <span class="invite-code">${inviteCode}</span>
@@ -74,14 +74,12 @@ const generateInviteEmail = (recipient, inviteCode) => {
             </p>
             <p>
                 Best regards,<br />
-                The MangoBlaze Team
-            </p>
+                Sam
+                </p>
             </td>
         </tr>
         <tr>
             <td style="text-align: center; font-size: 12px; color: #999999; padding: 10px 20px;">
-            &copy; 2025 [Your Company Name]. All rights reserved. <br />
-            1234 Your Address, City, State, ZIP Code
             </td>
         </tr>
         </table>

--- a/resend/welcome-template.js
+++ b/resend/welcome-template.js
@@ -59,26 +59,27 @@ const welcome = (recipient) => {
         <table role="presentation">
         <tr>
             <td>
-            <h1>Welcome to Our Platform!</h1>
+            <h1>Welcome to Love Light!</h1>
             <p>
                 Hi ${recipient},
             </p>
             <p>
-                We're thrilled to have you join us! Our platform is designed to help you [briefly mention what the platform does or provides]. Feel free to explore and make the most out of it.
+                Thank you for checking out Love Light! Love Light is a super simple way to 
+                connect with your partner through a simple traffic light system. You can use 
+                it to let your partner know how you're feeling at any time, and you can even 
+                set up notifications to remind you to check in with each other.
             </p>
             <p>
                 To get started, click the button below:
             </p>
-            <p>
-                <a href="[Your Link Here]" class="button">Get Started</a>
-            </p>
+            
             <p>
                 If you have any questions, feel free to reply to this email or contact us at <a href="mailto:support@example.com">support@example.com</a>.
             </p>
             <p>
                 Best regards,<br />
-                The MangoBlaze Team
-            </p>
+                Sam
+                </p>
             </td>
         </tr>
         <tr>

--- a/routes/resendRoutes.js
+++ b/routes/resendRoutes.js
@@ -36,18 +36,22 @@ router.post('/sendInvite', async (req,res) =>{
         html: generateInviteEmail(req.body.nickname, InviteCode),
       });
     
-    const inviter = await personModel.findOne({nickname: req.body.nickname})
-    console.log(req.body)
+    let inviter;
+    try {
+      inviter = await personModel.findOne({nickname: req.body.nickname});
+      if (!inviter) {
+        return res.status(404).send({ error: 'Inviter not found' });
+      }
 
-    console.log(inviter.id, "this is inviter")
-    
-    console.log(inviter)
-    if(typeof(InviteCode)){
-      const invitee = new personModel({partner: inviter.id, inviteCode: InviteCode, email: req.body.email})
-      await invitee.save();
-    } else{
-      console.log("not a string ")
-      console.log(typeof(InviteCode))
+      if(typeof(InviteCode)){
+            const invitee = new personModel({partner: inviter.id, inviteCode: InviteCode, email: req.body.email})
+            await invitee.save();
+          } else{
+            console.log("not a string ")
+            console.log(typeof(InviteCode))
+          }
+          } catch (err) {
+      return res.status(500).send({ error: 'Database error' });
     }
 
     // create a mongodb object with the invite code but also the objectid 


### PR DESCRIPTION
There was an error handing issue at resendRoutes.js that is now fixed to:
``` 
try {
      let inviter = await personModel.findOne({nickname: req.body.nickname});
      if (!inviter) {
        return res.status(404).send({ error: 'Inviter not found' });
      }

      if(typeof(InviteCode)){
            const invitee = new personModel({partner: inviter.id, inviteCode: InviteCode, email: req.body.email})
            await invitee.save();
          } else{
            console.log("not a string ")
            console.log(typeof(InviteCode))
          }
    } catch (err) {
        return res.status(500).send({ error: 'Database error' });
    } 
      if(typeof(InviteCode)){
            const invitee = new personModel({partner: inviter.id, inviteCode: InviteCode, email: req.body.email})
            await invitee.save();
          } else{
            console.log("not a string ")
            console.log(typeof(InviteCode))
          }
          } catch (err) {
      return res.status(500).send({ error: 'Database error' });
    }
```
basically the API endpoint would not check to see if the inviter existed before creating a new invitee middle document
